### PR TITLE
bugfix: Morse-key press updates ID

### DIFF
--- a/ns-glyde.bas
+++ b/ns-glyde.bas
@@ -235,6 +235,7 @@ namespace Glyde
         Glyde.hilightNext()
         if( Dict.containsKey( Glyde._keymap, chr( 9 ) ) ) then
             dim as string kdef = Dict.valueOf( Glyde._keymap, chr( 9 ) )
+            Glyde.setData( Glyde.D_LAST_HIT_BUTTON, Dict.valueOf( kdef, "id" ) )
             return Dict.valueOf( kdef, "label" )
         end if
         return Utils.EMPTY_STRING


### PR DESCRIPTION
If "onKeyPressed" has been called with "$morse_key" and a "useId" value,
"getLastActionId" would return "" instead of the specified value.  It
now returns the value
